### PR TITLE
chore: publish with cdklabs accounts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,29 @@ jobs:
           NPM_REGISTRY: registry.npmjs.org
     container:
       image: jsii/superchain
+  release_maven:
+    name: Release to Maven
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release@latest jsii-release-maven
+        env:
+          MAVEN_ENDPOINT: https://s01.oss.sonatype.org
+          MAVEN_GPG_PRIVATE_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PRIVATE_KEY_PASSPHRASE: ${{ secrets.MAVEN_GPG_PRIVATE_KEY_PASSPHRASE }}
+          MAVEN_PASSWORD: ${{ secrets.MAVEN_PASSWORD }}
+          MAVEN_USERNAME: ${{ secrets.MAVEN_USERNAME }}
+          MAVEN_STAGING_PROFILE_ID: ${{ secrets.MAVEN_STAGING_PROFILE_ID }}
+    container:
+      image: jsii/superchain
   release_pypi:
     name: Release to PyPi
     needs: release
@@ -91,5 +114,23 @@ jobs:
         env:
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+    container:
+      image: jsii/superchain
+  release_nuget:
+    name: Release to Nuget
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Download build artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: dist
+          path: dist
+      - name: Release
+        run: npx -p jsii-release@latest jsii-release-nuget
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
     container:
       image: jsii/superchain

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -14,6 +14,18 @@ const project = new AwsCdkConstructLibrary({
     distName: 'cdk-pipelines-github',
     module: 'cdk_pipelines_github',
   },
+
+  publishToMaven: {
+    javaPackage: 'io.github.cdklabs.cdkpipelines.github',
+    mavenGroupId: 'io.github.cdklabs',
+    mavenArtifactId: 'cdk-pipelines-github',
+    mavenEndpoint: 'https://s01.oss.sonatype.org',
+  },
+
+  publishToNuget: {
+    dotNetNamespace: 'Cdklabs.CdkPipelinesGitHub',
+    packageId: 'Cdklabs.CdkPipelinesGitHub',
+  },
 });
 
 project.addPeerDeps('@aws-cdk/core');

--- a/package.json
+++ b/package.json
@@ -123,9 +123,20 @@
   "jsii": {
     "outdir": "dist",
     "targets": {
+      "java": {
+        "package": "io.github.cdklabs.cdkpipelines.github",
+        "maven": {
+          "groupId": "io.github.cdklabs",
+          "artifactId": "cdk-pipelines-github"
+        }
+      },
       "python": {
         "distName": "cdk-pipelines-github",
         "module": "cdk_pipelines_github"
+      },
+      "dotnet": {
+        "namespace": "Cdklabs.CdkPipelinesGitHub",
+        "packageId": "Cdklabs.CdkPipelinesGitHub"
       }
     },
     "tsc": {


### PR DESCRIPTION
Migrate to use cdklabs accounts for publishing. While we are at it, publish to Maven and NuGet as well.