### PR TITLE
fix: synth job should have oidc permissions

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -465,7 +465,7 @@ export class GitHubWorkflow extends PipelineBase {
         name: 'Synthesize',
         permissions: {
           contents: github.JobPermission.READ,
-          // The Synthesize step does not use the GitHub Action Role on its own, but it's possible
+          // The Synthesize job does not use the GitHub Action Role on its own, but it's possible
           // that it is being used in the preBuildSteps.
           idToken: this.useGitHubActionRole ? github.JobPermission.WRITE : github.JobPermission.NONE,
         },

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -465,6 +465,9 @@ export class GitHubWorkflow extends PipelineBase {
         name: 'Synthesize',
         permissions: {
           contents: github.JobPermission.READ,
+          // The Synthesize step does not use the GitHub Action Role on its own, but it's possible
+          // that it is being used in the preBuildSteps.
+          idToken: this.useGitHubActionRole ? github.JobPermission.WRITE : github.JobPermission.NONE,
         },
         runsOn: this.runner.runsOn,
         needs: this.renderDependencies(node),

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -12,6 +12,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on: ubuntu-latest
     needs: []
     env: {}
@@ -393,6 +394,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on: windows-latest
     needs: []
     env: {}
@@ -424,6 +426,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: write
     runs-on: ubuntu-latest
     needs: []
     env: {}
@@ -548,6 +551,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on: ubuntu-latest
     needs: []
     env: {}
@@ -579,6 +583,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on: ubuntu-latest
     needs: []
     env: {}
@@ -698,6 +703,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on:
       - self-hosted
       - label1
@@ -732,6 +738,7 @@ jobs:
     name: Synthesize
     permissions:
       contents: read
+      id-token: none
     runs-on: ubuntu-latest
     needs: []
     env: {}


### PR DESCRIPTION
Fixes #174. Continuation of #172.

The Synthesize job does not use the OIDC role out of the box, so there was no need to configure permissions to allow it in that job. However, the job includes `preBuildSteps`, which are user-configured steps that could rely on the OIDC role to work (main use case: live lookups during synth time). It's not really recommended to introduce non-determinism in this way (see discussion on #174) but it needs to be supported nevertheless.

Co-authored-by: @awshilpa