### PR TITLE
fix: Add the environment attribute to workflow yml file conditionally

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -461,9 +461,9 @@ export class GitHubWorkflow extends PipelineBase {
           contents: github.JobPermission.READ,
           idToken: this.useGitHubActionRole ? github.JobPermission.WRITE : github.JobPermission.NONE,
         },
-        ...(this.stackEnvs[stack.stackArtifactId] && {
+        ...(this.stackEnvs[stack.stackArtifactId] ? {
           environment: this.stackEnvs[stack.stackArtifactId],
-        }),
+        } : {}),
         needs: this.renderDependencies(node),
         runsOn: this.runner.runsOn,
         steps: [

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -461,7 +461,9 @@ export class GitHubWorkflow extends PipelineBase {
           contents: github.JobPermission.READ,
           idToken: this.useGitHubActionRole ? github.JobPermission.WRITE : github.JobPermission.NONE,
         },
-        environment: this.stackEnvs[stack.stackArtifactId],
+        ...(this.stackEnvs[stack.stackArtifactId] && {
+          environment: this.stackEnvs[stack.stackArtifactId],
+        }),
         needs: this.renderDependencies(node),
         runsOn: this.runner.runsOn,
         steps: [

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -234,7 +234,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset1
@@ -266,7 +265,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset3
@@ -316,7 +314,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset5
@@ -351,7 +348,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset6
@@ -631,7 +627,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset1
@@ -791,7 +786,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset1
@@ -947,7 +941,6 @@ jobs:
     permissions:
       contents: read
       id-token: none
-    environment: null
     needs:
       - Build-Build
       - Assets-FileAsset1


### PR DESCRIPTION
Based on discussion https://github.com/cdklabs/cdk-pipelines-github/pull/178#discussion_r861411138

Removes `environment: null` from workflows that did not specify the environment.