### PR TITLE
chore: add a 'default' case to the pipeline type switch

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -358,6 +358,10 @@ export class GitHubWorkflow extends PipelineBase {
         } else {
           throw new Error(`unsupported step type: ${node.data.step.constructor.name}`);
         }
+
+      default:
+        // The 'as any' is temporary, until the change upstream rolls out
+        throw new Error(`GitHubWorfklow does not support graph nodes of type '${(node.data as any)?.type}'. You are probably using a feature this CDK Pipelines implementation does not support.`);
     }
   }
 


### PR DESCRIPTION
In https://github.com/aws/aws-cdk/pull/21619, we are making the exhaustiveness check for `GraphAnnotation` impossible on purpose, so that all CDK Pipelines implementations will be forced to add a `default` case to the `switch` (in preparation of future extensions of the graph model).

Add a `default` case here already to make sure we don't fail compilation.

Fixes #