### PR TITLE
chore: Update `yaml` dependency to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "decamelize": "^5.0.1",
     "fast-json-patch": "^3.1.1",
-    "yaml": "^1.10.2"
+    "yaml": "^2.1.2"
   },
   "bundledDependencies": [
     "decamelize",

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -387,7 +387,6 @@ jobs:
     runs-on: windows-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -420,7 +419,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -540,7 +538,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -665,7 +662,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -697,7 +693,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -817,7 +812,6 @@ jobs:
       - label2
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -849,7 +843,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/test/__snapshots__/stage-options.test.ts.snap
+++ b/test/__snapshots__/stage-options.test.ts.snap
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -135,7 +134,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -225,7 +223,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -315,7 +312,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -435,7 +431,6 @@ jobs:
     runs-on: ubuntu-latest
     needs: []
     env: {}
-    container: null
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/yarn.lock
+++ b/yarn.lock
@@ -6183,7 +6183,7 @@ yallist@^4.0.0:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
-yaml@1.10.2, yaml@^1.10.2:
+yaml@1.10.2:
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.10.2.tgz#2301c5ffbf12b467de8da2333a459e29e7920e4b"
   integrity sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==
@@ -6193,7 +6193,7 @@ yaml@2.0.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0.tgz#cbc588ad58e0cd924cd3f5f2b1a9485103048e25"
   integrity sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==
 
-yaml@^2.1.1:
+yaml@^2.1.1, yaml@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.2.tgz#eb0f535eb309811b60276a9cc8c02af4355db420"
   integrity sha512-VSdf2/K3FqAetooKQv45Hcu6sA00aDgWZeGcG6V9IYJnVLTnb6988Tie79K5nx2vK7cEpf+yW8Oy+7iPAbdiHA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -6193,7 +6193,7 @@ yaml@2.0.0:
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.0.0.tgz#cbc588ad58e0cd924cd3f5f2b1a9485103048e25"
   integrity sha512-JbfdlHKGP2Ik9IHylzWlGd4pPK++EU46/IxMykphS2ZKw7a7h+dHNmcXObLgpRDriBY+rpWslldikckX8oruWQ==
 
-yaml@^2.1.1:
+yaml@^2.1.1, yaml@^2.1.2:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.1.3.tgz#9b3a4c8aff9821b696275c79a8bee8399d945207"
   integrity sha512-AacA8nRULjKMX2DvWvOAdBZMOfQlypSFkjcOcu9FalllIDJ1kvlREzcdIZmidQUqqeMv7jorHjq2HlLv/+c2lg==


### PR DESCRIPTION
Part 1 of 2 for #349

All test passed locally, no new tests appear to be needed.