### PR TITLE
fix: version constraint for cdklabs-projen-project-types preventing upgrade to next minor version

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -36,7 +36,6 @@
     },
     {
       "name": "cdklabs-projen-project-types",
-      "version": "^0.0.9",
       "type": "build"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -15,7 +15,7 @@ const project = new CdklabsConstructLibrary({
   repositoryUrl: 'https://github.com/cdklabs/cdk-pipelines-github.git',
   bundledDeps: ['decamelize', 'yaml', 'fast-json-patch'],
   devDeps: [
-    'cdklabs-projen-project-types@^0.0.9',
+    'cdklabs-projen-project-types',
     'aws-cdk-lib',
     '@aws-cdk/integ-runner@^2.60.0',
     '@aws-cdk/integ-tests-alpha',


### PR DESCRIPTION
The version constraint prohibits us to go to the next minor version.