### PR TITLE
fix: make existingGitHubActionsProvider aware of AWS partitions

### DIFF
--- a/API.md
+++ b/API.md
@@ -743,7 +743,7 @@ You can do this manually in the console, or create a separate stack that uses th
 You must `cdk deploy` once (with your normal AWS credentials) to have this role created for you.
 
 You can then make note of the role arn in the stack output and send it into the Github Workflow app via
-the `gitHubActionRoleArn` property. The role arn will be `arn:aws:iam::<accountId>:role/GithubActionRole`.
+the `gitHubActionRoleArn` property. The role arn will be `arn:<partition>:iam::<accountId>:role/GithubActionRole`.
 
 > [https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services)
 

--- a/src/oidc-provider.ts
+++ b/src/oidc-provider.ts
@@ -77,7 +77,7 @@ export interface GitHubActionRoleProps {
  * You must `cdk deploy` once (with your normal AWS credentials) to have this role created for you.
  *
  * You can then make note of the role arn in the stack output and send it into the Github Workflow app via
- * the `gitHubActionRoleArn` property. The role arn will be `arn:aws:iam::<accountId>:role/GithubActionRole`.
+ * the `gitHubActionRoleArn` property. The role arn will be `arn:<partition>:iam::<accountId>:role/GithubActionRole`.
  *
  * @see https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services
  */
@@ -91,7 +91,7 @@ export class GitHubActionRole extends Construct {
     return iam.OpenIdConnectProvider.fromOpenIdConnectProviderArn(
       scope,
       'GitHubActionProvider',
-      `arn:aws:iam::${Aws.ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com`,
+      `arn:${Aws.PARTITION}:iam::${Aws.ACCOUNT_ID}:oidc-provider/token.actions.githubusercontent.com`,
     );
   }
 

--- a/test/oidc-provider.test.ts
+++ b/test/oidc-provider.test.ts
@@ -119,7 +119,11 @@ describe('GithubActionRole construct', () => {
                 'Fn::Join': [
                   '',
                   [
-                    'arn:aws:iam::',
+                    'arn:',
+                    {
+                      Ref: 'AWS::Partition',
+                    },
+                    ':iam::',
                     {
                       Ref: 'AWS::AccountId',
                     },


### PR DESCRIPTION
Replace hard coded 'aws' partition with a reference to the `AWS::Partition` in the current stack. This makes `GitHubActionRole` work for e.g. `aws-cn` too.

There are more work that needs to be done to get full aws-cn support (see #820), but this is a general fix and so could be merged independently.