### PR TITLE
fix: `cdk synth` creates incorrect file paths on Windows

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -554,7 +554,7 @@ export class GitHubWorkflow extends PipelineBase {
     this.assetHashMap[assetId] = jobId;
     fileContents.push(`echo '${ASSET_HASH_NAME}=${assetId}' >> $GITHUB_OUTPUT`);
 
-    const publishStepFile = path.join(path.dirname(relativeToAssembly(assetManifestPath)), `publish-${jobId}-step.sh`);
+    const publishStepFile = path.posix.join(path.dirname(relativeToAssembly(assetManifestPath)), `publish-${jobId}-step.sh`);
     mkdirSync(path.dirname(publishStepFile), { recursive: true });
     writeFileSync(publishStepFile, fileContents.join('\n'), { encoding: 'utf-8' });
 


### PR DESCRIPTION
Fixes #877

The complaint is that we are created file paths like `./cdk.out/assembly-OnstageCms\publish-Assets-FileAsset5-step.sh`. This is due to `path.join` defaulting to the system's separator (on windows, `\`). But GitHub actions use the posix version `/`. Instead, we should be using `path.posix.join`.