### PR TITLE
feat: enable all job settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@aws-cdk/integ-runner": "latest",
     "@aws-cdk/integ-tests-alpha": "latest",
+    "@schemastore/github-workflow": "^0.0.13",
     "@types/jest": "^27",
     "@types/node": "^18",
     "@typescript-eslint/eslint-plugin": "^6",

--- a/src/github-common.ts
+++ b/src/github-common.ts
@@ -1,6 +1,6 @@
 import { AddStageOpts } from 'aws-cdk-lib/pipelines';
-import { JobSettings } from './pipeline';
 import { StackCapabilities } from './stage-options';
+import { JobSettings } from './workflows-model';
 
 /**
  * Github environment with name and url.
@@ -56,7 +56,6 @@ export interface GitHubCommonProps {
 
   /**
    * Job level settings that will be applied to all jobs in the stage.
-   * Currently the only valid setting is 'if'.
    */
   readonly jobSettings?: JobSettings;
 }

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -13,6 +13,7 @@ import { GitHubStage } from './stage';
 import { GitHubActionStep } from './steps/github-action-step';
 import { GitHubWave } from './wave';
 import * as github from './workflows-model';
+import { JobSettings } from './workflows-model';
 import { YamlFile } from './yaml-file';
 
 const CDKOUT_ARTIFACT = 'cdk.out';
@@ -35,18 +36,6 @@ export interface DockerAssetJobSettings {
    * @default - no additional permissions
    */
   readonly permissions?: github.JobPermissions;
-}
-
-/**
- * Job level settings applied to all jobs in the workflow.
- */
-export interface JobSettings {
-  /**
-   * jobs.<job_id>.if.
-   *
-   * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idif
-   */
-  readonly if?: string;
 }
 
 /**
@@ -168,10 +157,9 @@ export interface GitHubWorkflowProps extends PipelineBaseProps {
 
   /**
    * Job level settings that will be applied to all jobs in the workflow,
-   * including synth and asset deploy jobs. Currently the only valid setting
-   * is 'if'. You can use this to run jobs only in specific repositories.
+   * including synth and asset deploy jobs.
    *
-   * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-only-run-job-for-specific-repository
+   * @see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
    */
   readonly jobSettings?: JobSettings;
 

--- a/src/workflows-model.ts
+++ b/src/workflows-model.ts
@@ -1,3 +1,4 @@
+import { Concurrency } from '@schemastore/github-workflow';
 // @see https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 
 /**
@@ -68,7 +69,7 @@ export interface Job {
    *
    * @experimental
    */
-  readonly concurrency?: unknown;
+  readonly concurrency?: Concurrency;
 
   /**
    * A map of outputs for a job. Job outputs are available to all downstream
@@ -131,8 +132,13 @@ export interface Job {
    * cycle of the service containers.
    */
   readonly services?: Record<string, ContainerOptions>;
-
 }
+
+/**
+ * Export a type where all job settings are set to optional.
+ * This enables additional job settings to be passed, without breaking existing functionality
+ */
+export type JobSettings = Partial<Job>;
 
 /**
  * The available scopes and access values for workflow permissions. If you

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -541,6 +541,9 @@ jobs:
   Build-Build:
     name: Synthesize
     if: github.repository == 'account/repo'
+    concurrency:
+      group: test-workflow
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: none
@@ -560,6 +563,9 @@ jobs:
   Assets-FileAsset1:
     name: Publish Assets Assets-FileAsset1
     if: github.repository == 'account/repo'
+    concurrency:
+      group: test-workflow
+      cancel-in-progress: false
     needs:
       - Build-Build
     permissions:
@@ -590,6 +596,9 @@ jobs:
   Assets-FileAsset2:
     name: Publish Assets Assets-FileAsset2
     if: github.repository == 'account/repo'
+    concurrency:
+      group: test-workflow
+      cancel-in-progress: false
     needs:
       - Build-Build
     permissions:
@@ -620,6 +629,9 @@ jobs:
   MyStack-MyStack-Deploy:
     name: Deploy MyStack098574E7
     if: github.repository == 'account/repo'
+    concurrency:
+      group: test-workflow
+      cancel-in-progress: false
     permissions:
       contents: read
       id-token: none

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -264,6 +264,10 @@ test('pipeline with job settings', () => {
       }),
       jobSettings: {
         if: 'github.repository == \'account/repo\'',
+        concurrency: {
+          group: 'test-workflow',
+          "cancel-in-progress": false,
+        }
       },
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -724,6 +724,11 @@
   resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
+"@schemastore/github-workflow@^0.0.13":
+  version "0.0.13"
+  resolved "https://registry.yarnpkg.com/@schemastore/github-workflow/-/github-workflow-0.0.13.tgz#2b885486c0dce7e7ceda768110f8a34e1959918c"
+  integrity sha512-hz5n713wACD9LxuFMiGe6QwCnZtldxAWnuGBUW8FGFU2/6aZoR0waVL14/nu9mO8twHA40blbZpbzc34mKjoww==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.6"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.6.tgz#80c516a4dc264c2a69115e7578d62581ff455ed9"


### PR DESCRIPTION
Fixes #915 . Open to feedback if there's a better way to do this, just tried to keep it simple. 

I've added @schemastore/github-workflow to get the typing for concurrency, but could also use that to get the type for Job instead of having to maintain that in this project