### PR TITLE
fix: resolve path compatibility issues on Windows devices

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -22,6 +22,12 @@ const project = new CdklabsConstructLibrary({
   ],
   peerDeps: ['aws-cdk-lib'],
   jestOptions: {
+    jestConfig: {
+      testMatch: [
+        '<rootDir>/test/**/*(*.)@(spec|test).ts?(x)',
+        '<rootDir>/src/**/*(*.)@(spec|test).ts?(x)',
+      ],
+    },
     updateSnapshot: UpdateSnapshot.NEVER,
   },
 

--- a/package.json
+++ b/package.json
@@ -95,9 +95,10 @@
   "version": "0.0.0",
   "jest": {
     "testMatch": [
-      "<rootDir>/src/**/__tests__/**/*.ts?(x)",
       "<rootDir>/test/**/*(*.)@(spec|test).ts?(x)",
-      "<rootDir>/src/**/*(*.)@(spec|test).ts?(x)"
+      "<rootDir>/src/**/*(*.)@(spec|test).ts?(x)",
+      "<rootDir>/src/**/__tests__/**/*.ts?(x)",
+      "<rootDir>/(test|src)/**/*(*.)@(spec|test).ts?(x)"
     ],
     "clearMocks": true,
     "collectCoverage": true,

--- a/package.json
+++ b/package.json
@@ -96,7 +96,8 @@
   "jest": {
     "testMatch": [
       "<rootDir>/src/**/__tests__/**/*.ts?(x)",
-      "<rootDir>/(test|src)/**/*(*.)@(spec|test).ts?(x)"
+      "<rootDir>/test/**/*(*.)@(spec|test).ts?(x)",
+      "<rootDir>/src/**/*(*.)@(spec|test).ts?(x)"
     ],
     "clearMocks": true,
     "collectCoverage": true,

--- a/src/private/posix-utils.ts
+++ b/src/private/posix-utils.ts
@@ -1,0 +1,5 @@
+import * as path from 'path';
+
+export function posixPath(windowsOrPosixPath: string): string {
+  return windowsOrPosixPath.split(path.sep).join(path.posix.sep);
+}


### PR DESCRIPTION
# tl;dr
Fixes #877

- Updates Jest config globs that did not match any tests on Windows device
- Resolves tests that fail when run on Windows platform
- Uses a helper `posixPath` function to convert all windows separators to posix instead of trying to find and replace all necessary instances of `path` module that would need to convert separators to be posix compliant

# More Info
Follow up to issue https://github.com/cdklabs/cdk-pipelines-github/issues/877 and original change https://github.com/cdklabs/cdk-pipelines-github/pull/880 which partially resolved issues

Additionally, fixed up Jest config so that tests run on Windows device:
Before updating `testMatch`:
```
$ yarn test
yarn run v1.22.21
$ npx projen test
👾 test | jest --passWithNoTests --coverageProvider=v8 --ci
No tests found, exiting with code 0
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                  
----------|---------|----------|---------|---------|-------------------
```

After updating `testMatch`:
```
Snapshot Summary
 › 26 snapshots failed from 6 test suites. Inspect your code changes or re-run jest with `-u` to update them.

Test Suites: 7 failed, 2 passed, 9 total
Tests:       36 failed, 45 passed, 81 total
Snapshots:   26 failed, 13 passed, 39 total
Time:        39.922 s
Ran all test suites.
```

After posix path changes:
```
Test Suites: 9 passed, 9 total
Tests:       88 passed, 88 total
Snapshots:   43 passed, 43 total
Time:        40.989 s
Ran all test suites.
```