### PR TITLE
fix(pipeline): use `fail-on-empty-changeset` input for CloudFormation deploy action

### DIFF
--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -646,7 +646,7 @@ export class GitHubWorkflow extends PipelineBase {
     const params: Record<string, any> = {
       'name': stack.stackName,
       'template': replaceAssetHash(resolve(stack.templateUrl)),
-      'no-fail-on-empty-changeset': '1',
+      'fail-on-empty-changeset': false,
     };
 
     const capabilities = this.stackProperties[stack.stackArtifactId]?.capabilities;

--- a/test/__snapshots__/github.cn.test.ts.snap
+++ b/test/__snapshots__/github.cn.test.ts.snap
@@ -253,7 +253,7 @@ jobs:
           name: StageA-BucketStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   StageA-FunctionStack-Deploy:
     name: Deploy StageAFunctionStackD42C27B8
@@ -285,7 +285,7 @@ jobs:
           name: StageA-FunctionStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset3.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
     outputs:
       myout: \${{ steps.Deploy.outputs.myout }}
@@ -334,7 +334,7 @@ jobs:
           name: StageB-BucketStack
           template: https://cdk-hnb659fds-assets-222222222222-cn-northwest-1.s3.cn-northwest-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset5.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-cn-northwest-1
   StageB-FunctionStack-Deploy:
     name: Deploy StageBFunctionStack18098DCD
@@ -369,7 +369,7 @@ jobs:
           name: StageB-FunctionStack
           template: https://cdk-hnb659fds-assets-222222222222-cn-northwest-1.s3.cn-northwest-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset6.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-cn-northwest-1
 "
 `;
@@ -489,7 +489,7 @@ jobs:
           name: MyStage-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;
@@ -648,7 +648,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;
@@ -776,7 +776,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;
@@ -931,7 +931,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;
@@ -1089,7 +1089,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;

--- a/test/__snapshots__/github.test.ts.snap
+++ b/test/__snapshots__/github.test.ts.snap
@@ -253,7 +253,7 @@ jobs:
           name: StageA-BucketStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   StageA-FunctionStack-Deploy:
     name: Deploy StageAFunctionStackD42C27B8
@@ -285,7 +285,7 @@ jobs:
           name: StageA-FunctionStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset3.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
     outputs:
       myout: \${{ steps.Deploy.outputs.myout }}
@@ -334,7 +334,7 @@ jobs:
           name: StageB-BucketStack
           template: https://cdk-hnb659fds-assets-222222222222-eu-west-2.s3.eu-west-2.amazonaws.com/\${{
             needs.Assets-FileAsset5.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-eu-west-2
   StageB-FunctionStack-Deploy:
     name: Deploy StageBFunctionStack18098DCD
@@ -369,7 +369,7 @@ jobs:
           name: StageB-FunctionStack
           template: https://cdk-hnb659fds-assets-222222222222-eu-west-2.s3.eu-west-2.amazonaws.com/\${{
             needs.Assets-FileAsset6.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-eu-west-2
 "
 `;
@@ -489,7 +489,7 @@ jobs:
           name: MyStage-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -657,7 +657,7 @@ jobs:
           name: MyStage-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -790,7 +790,7 @@ jobs:
           name: MyStage-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -922,7 +922,7 @@ jobs:
           name: MyStage-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -1014,7 +1014,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -1176,7 +1176,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -1304,7 +1304,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -1459,7 +1459,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -1617,7 +1617,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;

--- a/test/__snapshots__/runner-provided.cn.test.ts.snap
+++ b/test/__snapshots__/runner-provided.cn.test.ts.snap
@@ -69,7 +69,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;

--- a/test/__snapshots__/runner-provided.test.ts.snap
+++ b/test/__snapshots__/runner-provided.test.ts.snap
@@ -69,7 +69,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;

--- a/test/__snapshots__/stage-options.cn.test.ts.snap
+++ b/test/__snapshots__/stage-options.cn.test.ts.snap
@@ -107,7 +107,7 @@ jobs:
           name: MyPrePostStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   MyPrePostStack-PostDeployAction:
     name: PostDeployAction
@@ -217,7 +217,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
@@ -310,7 +310,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           capabilities: CAPABILITY_NAMED_IAM
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
@@ -404,7 +404,7 @@ jobs:
           name: MyStage1-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   MyStage2-MyStack-Deploy:
     name: Deploy MyStage2MyStack9B82AF96
@@ -434,7 +434,7 @@ jobs:
           name: MyStage2-MyStack
           template: https://cdk-hnb659fds-assets-222222222222-cn-northwest-1.s3.cn-northwest-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-cn-northwest-1
 "
 `;
@@ -548,7 +548,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -578,7 +578,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-cn-north-1
   MyWave-PostWaveAction:
     name: PostWaveAction
@@ -691,7 +691,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
 "
 `;
@@ -784,7 +784,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -813,7 +813,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-cn-north-1
 "
 `;
@@ -906,7 +906,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-cn-north-1
   MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -936,7 +936,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-cn-north-1.s3.cn-north-1.amazonaws.com.cn/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws-cn:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-cn-north-1
 "
 `;

--- a/test/__snapshots__/stage-options.test.ts.snap
+++ b/test/__snapshots__/stage-options.test.ts.snap
@@ -107,7 +107,7 @@ jobs:
           name: MyPrePostStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   MyPrePostStack-PostDeployAction:
     name: PostDeployAction
@@ -217,7 +217,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_IAM,CAPABILITY_AUTO_EXPAND
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
@@ -310,7 +310,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           capabilities: CAPABILITY_NAMED_IAM
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
@@ -404,7 +404,7 @@ jobs:
           name: MyStage1-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   MyStage2-MyStack-Deploy:
     name: Deploy MyStage2MyStack9B82AF96
@@ -434,7 +434,7 @@ jobs:
           name: MyStage2-MyStack
           template: https://cdk-hnb659fds-assets-222222222222-us-west-2.s3.us-west-2.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::222222222222:role/cdk-hnb659fds-cfn-exec-role-222222222222-us-west-2
 "
 `;
@@ -548,7 +548,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -578,7 +578,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-us-east-1
   MyWave-PostWaveAction:
     name: PostWaveAction
@@ -691,7 +691,7 @@ jobs:
           name: MyStack-MyStack
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
 "
 `;
@@ -784,7 +784,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   MyWave-MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -813,7 +813,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-us-east-1
 "
 `;
@@ -906,7 +906,7 @@ jobs:
           name: MyStageA-MyStackA
           template: https://cdk-hnb659fds-assets-111111111111-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::111111111111:role/cdk-hnb659fds-cfn-exec-role-111111111111-us-east-1
   MyStageB-MyStackB-Deploy:
     name: Deploy MyStageBMyStackBFE4B1ADE
@@ -936,7 +936,7 @@ jobs:
           name: MyStageB-MyStackB
           template: https://cdk-hnb659fds-assets-12345678901-us-east-1.s3.us-east-1.amazonaws.com/\${{
             needs.Assets-FileAsset1.outputs.asset-hash }}.json
-          no-fail-on-empty-changeset: \\"1\\"
+          fail-on-empty-changeset: false
           role-arn: arn:aws:iam::12345678901:role/cdk-hnb659fds-cfn-exec-role-12345678901-us-east-1
 "
 `;


### PR DESCRIPTION
The `aws-actions/aws-cloudformation-github-deploy` action was bumped to its latest major version in #1451, but that release also renamed the `no-fail-on-empty-changeset` input to `fail-on-empty-changeset` and switched it from a stringified flag to a proper boolean. The generated workflows still emit the old input name, which the new action version no longer recognises, so deploys that produce an empty changeset fail instead of succeeding silently.

Emit `fail-on-empty-changeset: false` to preserve the existing behaviour with the current action version. The snapshot updates reflect the new rendering in generated workflow YAML.

Fixes #
